### PR TITLE
Remove trailing page numbers from category headers

### DIFF
--- a/app.py
+++ b/app.py
@@ -181,9 +181,11 @@ def extract_page_headers(pdf_reader):
                         continue
                     
                     # Look for header pattern: text followed by optional page number
-                    header_match = re.search(r'^(.*?)(?:\s+\d+\s*)?$', line)
+                    header_match = re.search(r'^(.*?)(?:\s*\d+\s*)?$', line)
                     if header_match:
                         potential_category = header_match.group(1).strip()
+                        # Remove trailing digits that may be directly attached
+                        potential_category = re.sub(r'\d+$', '', potential_category).strip()
                         
                         # Skip if it's just a number or too short
                         if potential_category.isdigit() or len(potential_category) < 5:
@@ -192,6 +194,8 @@ def extract_page_headers(pdf_reader):
                         # Remove any parenthetical content and clean up
                         clean_category = re.sub(r'\s*\(.*?\)\s*', '', potential_category)
                         clean_category = re.sub(r'^\d+\.\s*', '', clean_category)  # Remove leading numbers
+                        # Remove trailing digits that may have been joined with the header
+                        clean_category = re.sub(r'\d+$', '', clean_category)
                         clean_category = clean_category.strip()
                         
                         if clean_category:


### PR DESCRIPTION
## Summary
- fix regex in `extract_page_headers` so page numbers appended to headers are stripped
- strip trailing digits from cleaned header text

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6846264221d08323880f91e11686d9a3