### PR TITLE
Align high error percentage chart styling

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -316,7 +316,8 @@
                 options: {
                     maintainAspectRatio: false,
                     plugins: {
-                        legend: { display: false },
+                        title: { display: false },
+                        legend: { position: 'top' },
                         tooltip: {
                             callbacks: {
                                 label: function(context) {
@@ -325,7 +326,16 @@
                             }
                         }
                     },
+                    responsive: true,
                     scales: {
+                        x: {
+                            ticks: {
+                                autoSkip: false,
+                                maxRotation: 45,
+                                minRotation: 45,
+                                font: { size: 11 }
+                            }
+                        },
                         y: {
                             beginAtZero: true,
                             ticks: {


### PR DESCRIPTION
## Summary
- adjust `createPercentageBarChart` options so they match the stacked bar charts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68484df636508323b21b15ab1d717edf