### PR TITLE
Improve summary statistics display

### DIFF
--- a/app.py
+++ b/app.py
@@ -579,6 +579,9 @@ Provide a concise, bullet-pointed list of 5-7 key teaching points that would be 
 def index():
     empty_result = {
         'stats': {
+            '60-79': 0,
+            '80+': 0,
+            'total_questions': 0,
             'category_summary': {
                 'total_pages': 0,
                 'uncategorized_pages': 0,
@@ -647,6 +650,8 @@ def analyze():
         
         # Add question counts to category summary
         category_summary['category_questions'] = category_question_counts
+        total_questions = sum(category_question_counts.values())
+        category_summary['total_questions'] = total_questions
         
         # Count high-error questions per category using the passed category_questions
         for error_range, questions in high_error_questions.items():
@@ -705,6 +710,7 @@ def analyze():
             'stats': {
                 '60-79': len(high_error_questions['60-79']),
                 '80+': len(high_error_questions['80+']),
+                'total_questions': total_questions,
                 'categories': subcategory_stats,
                 'general_categories': general_category_stats,
                 'population': population_stats,

--- a/templates/index.html
+++ b/templates/index.html
@@ -77,10 +77,12 @@
                     <div class="bg-yellow-50 p-4 rounded-lg">
                         <h3 class="text-lg font-medium text-yellow-800">60-79% Wrong</h3>
                         <p id="stat-60-79" class="text-2xl font-bold text-yellow-900">0</p>
+                        <p id="pct-60-79" class="text-sm text-yellow-700"></p>
                     </div>
                     <div class="bg-red-50 p-4 rounded-lg">
                         <h3 class="text-lg font-medium text-red-800">80%+ Wrong</h3>
                         <p id="stat-80-plus" class="text-2xl font-bold text-red-900">0</p>
+                        <p id="pct-80-plus" class="text-sm text-red-700"></p>
                     </div>
                 </div>
 
@@ -113,7 +115,8 @@
                     </div>
                 </div>
 
-                <!-- Charts Section -->
+                <!-- Charts Section (temporarily hidden) -->
+                <!--
                 <div class="mt-8 space-y-6">
                     <div class="chart-wrapper">
                         <h3 class="text-lg font-medium text-gray-800 mb-2">Distribution by Topic/Subject Area</h3>
@@ -128,6 +131,7 @@
                         <canvas id="populationChart"></canvas>
                     </div>
                 </div>
+                -->
                 
                 <!-- Teaching Points Section -->
                 <div class="mt-8 bg-blue-50 p-6 rounded-lg">
@@ -398,8 +402,8 @@
                                     </div>
                                 </div>
                                 <div id="${detailId}" class="hidden p-2 bg-gray-50 space-y-2">
-                                    <p class="text-sm text-gray-700">Majority Incorrectly Answered: ${highErrPercent}%</p>
-                                    <p class="text-sm text-gray-700 mb-2">Majority Correctly Answered: ${correctPercent}%</p>
+                                    <h4 class="text-sm font-semibold text-gray-700">Majority Incorrectly Answered: ${highErrPercent}%</h4>
+                                    <h4 class="text-sm font-semibold text-gray-700 mb-2">Majority Correctly Answered: ${correctPercent}%</h4>
                                     <div class="space-y-4">${questionCards}</div>
                                 </div>
                             </div>
@@ -417,6 +421,11 @@
                     // Update statistics
                     document.getElementById('stat-60-79').textContent = data.stats['60-79'];
                     document.getElementById('stat-80-plus').textContent = data.stats['80+'];
+                    const totalQuestions = data.stats.total_questions || 0;
+                    if (totalQuestions) {
+                        document.getElementById('pct-60-79').textContent = ((data.stats['60-79'] / totalQuestions) * 100).toFixed(1) + '%';
+                        document.getElementById('pct-80-plus').textContent = ((data.stats['80+'] / totalQuestions) * 100).toFixed(1) + '%';
+                    }
                     
                     // Create charts
                     const percentData = {};
@@ -425,9 +434,9 @@
                         percentData[cat] = total ? ((highErr / total) * 100).toFixed(1) : 0;
                     });
                     createPercentageBarChart(percentData, 'highErrorPercentageChart', 'High-Error Question Percentage by Category');
-                    createStackedBarChart(data.stats.categories, 'categoryChart', 'Questions by Topic/Subject Area');
-                    createStackedBarChart(data.stats.general_categories, 'generalCategoryChart', 'Questions by General Category');
-                    createStackedBarChart(data.stats.population, 'populationChart', 'Questions by Population Type');
+                    // createStackedBarChart(data.stats.categories, 'categoryChart', 'Questions by Topic/Subject Area');
+                    // createStackedBarChart(data.stats.general_categories, 'generalCategoryChart', 'Questions by General Category');
+                    // createStackedBarChart(data.stats.population, 'populationChart', 'Questions by Population Type');
                     
                     // Update teaching points
                     const teachingPointsDiv = document.getElementById('teaching-points');


### PR DESCRIPTION
## Summary
- show percentage of high-error questions in the summary stats
- hide distribution charts for now
- emphasize majority correct/incorrect lines as subheadings
- send total question count from backend

## Testing
- `python -m py_compile app.py`
- `pytest` *(fails: no tests configured)*

------
https://chatgpt.com/codex/tasks/task_e_6849aac3166c8323bbd65e1b8e841639