### PR TITLE
Show high-error counts per subcategory

### DIFF
--- a/app.py
+++ b/app.py
@@ -645,7 +645,8 @@ def analyze():
             'uncategorized_pages': sum(1 for cat in page_categories.values() if cat == "Uncategorized"),
             'category_frequency': {},
             'high_error_counts': {},  # Add tracking for high-error questions per category
-            'subcategory_counts': category_subcategories
+            'subcategory_counts': category_subcategories,
+            'subcategory_high_error_counts': {}
         }
         
         # Count frequency of each category and initialize high-error counts
@@ -657,6 +658,7 @@ def analyze():
                     '80+': 0,
                     'total': 0
                 }
+                category_summary['subcategory_high_error_counts'][category] = {}
         
         # Add question counts to category summary
         category_summary['category_questions'] = category_question_counts
@@ -671,6 +673,12 @@ def analyze():
                     if q_num in q_set:
                         category_summary['high_error_counts'][category][error_range] += 1
                         category_summary['high_error_counts'][category]['total'] += 1
+                        # Track subcategory high-error counts
+                        if isinstance(question_info.get(q_num), dict):
+                            sub = question_info[q_num].get('subcategory')
+                            if sub:
+                                sub_dict = category_summary['subcategory_high_error_counts'].setdefault(category, {})
+                                sub_dict[sub] = sub_dict.get(sub, 0) + 1
                         break
         
         # Sort categories by frequency

--- a/templates/index.html
+++ b/templates/index.html
@@ -391,9 +391,16 @@
                             createQuestionCard(q.num, q.info, q.range === '60-79' ? 'border-yellow-400' : 'border-red-400')
                         ).join('') || '<p class="text-gray-500">No high-error questions.</p>';
                         const subCounts = data.stats.category_summary.subcategory_counts[category] || {};
-                        const subList = Object.entries(subCounts).map(([sub, count]) =>
-                            `<span class="block ml-4 text-xs text-gray-700">${sub}: ${count}</span>`
-                        ).join('');
+                        const subHighCounts = data.stats.category_summary.subcategory_high_error_counts[category] || {};
+                        const subList = Object.entries(subCounts).map(([sub, count]) => {
+                            const high = subHighCounts[sub] || 0;
+                            return `<span class="block ml-4 text-xs text-gray-700">${sub}: ${count}${high ? ` (${high} high-error)` : ''}</span>`;
+                        }).join('');
+                        const subHighList = Object.entries(subHighCounts).map(([sub, count]) => {
+                            const total = subCounts[sub] || 0;
+                            const pct = total ? ((count / total) * 100).toFixed(1) : 0;
+                            return `<li>${pct}% high-error rate in ${sub}</li>`;
+                        }).join('');
 
                         categoryList.innerHTML += `
                             <div class="border rounded">
@@ -408,6 +415,7 @@
                                  <div id="${detailId}" class="hidden p-2 bg-gray-50 space-y-2">
                                      ${subList ? `<div class="text-xs text-gray-700">${subList}</div>` : ''}
                                      <h4 class="text-md font-bold text-red-700">Amount of Questions Incorrectly Answered by More than 60% of Residents: ${highErrPercent}%</h4>
+                                     ${subHighList ? `<ul class="list-disc ml-8 text-sm text-red-700">${subHighList}</ul>` : ''}
                                      <div class="pl-4 space-y-4">${questionCards}</div>
                                      <h4 class="text-sm font-semibold text-gray-700 mt-2">Majority Correctly Answered: ${correctPercent}%</h4>
                                  </div>


### PR DESCRIPTION
## Summary
- track high-error question counts by subcategory
- display subcategory high-error counts and percentages in the UI

## Testing
- `python -m py_compile app.py`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6849d9fa4440832380d9b2940445c6f2