### PR TITLE
Move majority correct section

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -416,8 +416,8 @@
                                      ${subList ? `<div class="text-xs text-gray-700">${subList}</div>` : ''}
                                      <h4 class="text-md font-bold text-red-700">Amount of Questions Incorrectly Answered by More than 60% of Residents: ${highErrPercent}%</h4>
                                      ${subHighList ? `<ul class="list-disc ml-8 text-sm text-red-700">${subHighList}</ul>` : ''}
+                                     <h4 class="text-md font-bold text-green-700">Majority Correctly Answered: ${correctPercent}%</h4>
                                      <div class="pl-4 space-y-4">${questionCards}</div>
-                                     <h4 class="text-sm font-semibold text-gray-700 mt-2">Majority Correctly Answered: ${correctPercent}%</h4>
                                  </div>
                             </div>
                         `;


### PR DESCRIPTION
## Summary
- reorder Majority Correctly Answered section so it appears above question summaries
- use same header style as error rate but in green

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6849df3acde483238c7b81ed80f56710